### PR TITLE
Versionlock kernel-headers

### DIFF
--- a/centos-lustre-templates/.gitignore
+++ b/centos-lustre-templates/.gitignore
@@ -1,3 +1,6 @@
 *.box
 packer_cache
 rpms
+*.vdi
+*.ovf
+*.vmdk

--- a/centos-lustre-templates/httpfiles/kickstart/base.ks
+++ b/centos-lustre-templates/httpfiles/kickstart/base.ks
@@ -39,6 +39,9 @@ selinux --disabled
 %end
 
 %post
+# Versionlock kernel-headers
+yum -y install yum-plugin-versionlock
+yum versionlock kernel-headers-3.10.0-693.el7.x86_64
 # Download the default public key for the vagrant user from the 
 # Vagrant GitHub project. Used by all public base boxes for first
 # time boot.


### PR DESCRIPTION
Both guest additions and patched lustre want consistent kernel / kernel-headers.

version lock the kernel headers so they don't autoupdate.

Signed-off-by: Joe Grund <joe.grund@intel.com>