### PR TITLE
Install latest kernel / kernel-headers

### DIFF
--- a/centos-lustre-templates/httpfiles/kickstart/base.ks
+++ b/centos-lustre-templates/httpfiles/kickstart/base.ks
@@ -37,10 +37,9 @@ selinux --disabled
 %end
 
 %post
-# Versionlock kernel-headers
-yum -y install yum-plugin-versionlock
-yum versionlock kernel-headers-3.10.0-693.2.2.el7.x86_64
-yum install -y kernel-3.10.0-693.2.2.el7.x86_64 kernel-tools-3.10.0-693.2.2.el7.x86_64
+# Versionlock kernel-headers and install latest kernel
+yum -y install kernel kernel-headers kernel-tools yum-plugin-versionlock
+yum versionlock kernel-headers
 # Download the default public key for the vagrant user from the 
 # Vagrant GitHub project. Used by all public base boxes for first
 # time boot.


### PR DESCRIPTION
In order to satisfy both vbox guest and patched lustre, we need to build boxes for each supported kernel.

We can do this by both pinning the kernel headers (so they don't upgrade on vbox guest install), and building a box for each kernel version.

Upgrade to the latest kernel. A new version of the box will need to be created each time the kernel revs and Lustre intends to support it.