### PR TITLE
Remove rsync as sync type

### DIFF
--- a/centos-lustre-templates/Vagrantfile
+++ b/centos-lustre-templates/Vagrantfile
@@ -1,4 +1,4 @@
 # vi: set ft=ruby :
 Vagrant.configure("2") do |config|
-	config.vm.synced_folder ".", "/vagrant", type: "rsync"
+	config.vm.synced_folder ".", "/vagrant"
 end


### PR DESCRIPTION
Remove `rsync` as the sync type. Let Vagrant figure out how it should sync the folder instead.